### PR TITLE
DateTimePicker: Fix date value change by one day on edit

### DIFF
--- a/app/inputs/date_time_picker_input.rb
+++ b/app/inputs/date_time_picker_input.rb
@@ -5,7 +5,7 @@ class DateTimePickerInput < ActiveAdminAddons::InputBase
     load_attr(:maxlength, value: 19)
     load_attr(:autocomplete, value: 'off')
     load_attr(:value, value: formatted_input_value)
-    load_attr(:'data-iso8601-value', value: input_value&.iso8601)
+    load_attr(:'data-iso8601-value', value: input_value&.to_time&.iso8601)
   end
 
   def formatted_input_value


### PR DESCRIPTION
When we use the `DateTimePicker` input without the time, it changes the `date` value, by one day, on edit.
We need to keep information about the timezone to be able to keep the correct date value.